### PR TITLE
Fix error to wrong filename in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ever need a TileJSON file for your .mbtiles? This tiny tool does that:
 ```
 $ npm install -g tileinfo
 
-$ tileinfo mytiles.json
+$ tileinfo mytiles.mbtiles
 {
   "scheme": "tms",
   "basename": "mytiles.mbtiles",


### PR DESCRIPTION
Fix an inconsistency between https://github.com/stevage/tileinfo/blob/master/index.js#L7 and the README.md example.